### PR TITLE
fix(Rest): use reference type for DOM

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"test:ci": "yarn test --verbose --noStackTrace",
 		"prebuild": "yarn clean",
 		"build": "tsc --build packages/core packages/rest packages/ws --force",
-		"clean": "rimraf packages/**/dist",
+		"clean": "rimraf packages/**/dist packages/**/*.tsbuildinfo",
 		"lint": "eslint packages --ext mjs,js,ts",
 		"lint:fix": "eslint packages --ext mjs,js,ts --fix",
 		"format": "prettier --write **/*.{ts,js,json,yml,yaml}",

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -1,3 +1,6 @@
+// eslint-disable-next-line spaced-comment
+/// <reference lib="dom" />
+
 export * from './lib/CDN';
 export * from './lib/errors/DiscordAPIError';
 export * from './lib/errors/HTTPError';

--- a/packages/rest/src/lib/RequestManager.ts
+++ b/packages/rest/src/lib/RequestManager.ts
@@ -192,7 +192,7 @@ export class RequestManager extends EventEmitter {
 
 		// If a query option is passed, use it
 		if (request.query) {
-			query = `?${request.query.toString() as string}`;
+			query = `?${request.query.toString()}`;
 		}
 
 		// Create the required headers

--- a/packages/rest/tsconfig.json
+++ b/packages/rest/tsconfig.json
@@ -4,7 +4,7 @@
 		"sourceRoot": "./",
 		"rootDir": "./src",
 		"outDir": "dist",
-		"lib": ["ESNext", "DOM"]
+		"lib": ["ESNext"]
 	},
 	"include": ["src"],
 	"references": [{ "path": "../core" }]


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

We had someone in Sapphire running into an issue here because they didn't have "DOM" in their tsconfig lib.

Instead of having "DOM" in the tsconfig `compilerOptions.lib` we can just use a triple slash directive, which gets copied over to the output `index.d.ts`. This way our code compiles and works fine and library users won't have any issues.

Here is a screencap of when the person in Sapphire was having the issue:

![image](https://user-images.githubusercontent.com/4019718/130443514-9a060943-f5d1-4f5e-b0e9-ac6c2761de84.png)

Note that at the time we had a short discussion about this starting with Vladdy saying that people should just add `"skipLibCheck": true` but I entirely disagree with that.

`skipLibCheck` is a duct tape solution to a problem that shouldn't exist in the  first place. Now if https://www.typescriptlang.org/tsconfig/#skipLibCheck or any other guide on the website  recommended using this option, sure, I could see some reason to recommend using that instead of making this change... but that's not the case. In fact, it even recommends _against_ using `skipLibCheck` and preferring other solutions.

---

On a sidenote, I also fixed the "clean" script to also delete `.tsbuildinfo` files. Otherwise running "build" after "clean" outputs nothing because TS incremental will just think that files are still there.

---


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
