### PR TITLE
refactor(CDN): generalize method names

### DIFF
--- a/packages/rest/__tests__/CDN.test.ts
+++ b/packages/rest/__tests__/CDN.test.ts
@@ -66,12 +66,12 @@ test('teamIcon default', () => {
 
 test('makeURL throws on invalid size', () => {
 	// @ts-expect-error: Invalid size
-	expect(() => cdn.userAvatar(id, animatedHash, { size: 5 })).toThrow(RangeError);
+	expect(() => cdn.avatar(id, animatedHash, { size: 5 })).toThrow(RangeError);
 });
 
 test('makeURL throws on invalid extension', () => {
 	// @ts-expect-error: Invalid extension
-	expect(() => cdn.userAvatar(id, animatedHash, { extension: 'tif' })).toThrow(RangeError);
+	expect(() => cdn.avatar(id, animatedHash, { extension: 'tif' })).toThrow(RangeError);
 });
 
 test('makeURL valid size', () => {

--- a/packages/rest/__tests__/CDN.test.ts
+++ b/packages/rest/__tests__/CDN.test.ts
@@ -16,6 +16,26 @@ test('appIcon default', () => {
 	expect(cdn.appIcon(id, hash)).toBe(`${base}/app-icons/${id}/${hash}.png`);
 });
 
+test('avatar default', () => {
+	expect(cdn.avatar(id, animatedHash)).toBe(`${base}/avatars/${id}/${animatedHash}.png`);
+});
+
+test('avatar dynamic-animated', () => {
+	expect(cdn.avatar(id, animatedHash, { dynamic: true })).toBe(`${base}/avatars/${id}/${animatedHash}.gif`);
+});
+
+test('avatar dynamic-not-animated', () => {
+	expect(cdn.avatar(id, hash, { dynamic: true })).toBe(`${base}/avatars/${id}/${hash}.png`);
+});
+
+test('banner default', () => {
+	expect(cdn.banner(id, hash)).toBe(`${base}/banners/${id}/${hash}.png`);
+});
+
+test('channelIcon default', () => {
+	expect(cdn.channelIcon(id, hash)).toBe(`${base}/channel-icons/${id}/${hash}.png`);
+});
+
 test('defaultAvatar default', () => {
 	expect(cdn.defaultAvatar(defaultAvatar)).toBe(`${base}/embed/avatars/${defaultAvatar}.png`);
 });
@@ -32,16 +52,8 @@ test('emoji gif', () => {
 	expect(cdn.emoji(id, 'gif')).toBe(`${base}/emojis/${id}.gif`);
 });
 
-test('groupDMIcon default', () => {
-	expect(cdn.groupDMIcon(id, hash)).toBe(`${base}/channel-icons/${id}/${hash}.png`);
-});
-
-test('guildBanner default', () => {
-	expect(cdn.guildBanner(id, hash)).toBe(`${base}/banners/${id}/${hash}.png`);
-});
-
-test('guildIcon default', () => {
-	expect(cdn.guildIcon(id, hash)).toBe(`${base}/icons/${id}/${hash}.png`);
+test('icon default', () => {
+	expect(cdn.icon(id, hash)).toBe(`${base}/icons/${id}/${hash}.png`);
 });
 
 test('splash default', () => {
@@ -50,18 +62,6 @@ test('splash default', () => {
 
 test('teamIcon default', () => {
 	expect(cdn.teamIcon(id, hash)).toBe(`${base}/team-icons/${id}/${hash}.png`);
-});
-
-test('userAvatar default', () => {
-	expect(cdn.userAvatar(id, animatedHash)).toBe(`${base}/avatars/${id}/${animatedHash}.png`);
-});
-
-test('userAvatar dynamic-animated', () => {
-	expect(cdn.userAvatar(id, animatedHash, { dynamic: true })).toBe(`${base}/avatars/${id}/${animatedHash}.gif`);
-});
-
-test('userAvatar dynamic-not-animated', () => {
-	expect(cdn.userAvatar(id, hash, { dynamic: true })).toBe(`${base}/avatars/${id}/${hash}.png`);
 });
 
 test('makeURL throws on invalid size', () => {
@@ -75,5 +75,5 @@ test('makeURL throws on invalid extension', () => {
 });
 
 test('makeURL valid size', () => {
-	expect(cdn.userAvatar(id, animatedHash, { size: 512 })).toBe(`${base}/avatars/${id}/${animatedHash}.png?size=512`);
+	expect(cdn.avatar(id, animatedHash, { size: 512 })).toBe(`${base}/avatars/${id}/${animatedHash}.png?size=512`);
 });

--- a/packages/rest/src/lib/CDN.ts
+++ b/packages/rest/src/lib/CDN.ts
@@ -33,6 +33,40 @@ export class CDN {
 	}
 
 	/**
+	 * Generates an avatar URL, e.g. for a user or a webhook.
+	 * @param id The id that has the icon
+	 * @param avatarHash The hash provided by Discord for this avatar
+	 * @param options Optional options for the avatar
+	 */
+	public avatar(id: string, avatarHash: string, { dynamic = false, ...options }: ImageURLOptions = {}): string {
+		if (dynamic && avatarHash.startsWith('a_')) {
+			options.extension = 'gif';
+		}
+
+		return this.makeURL(`/avatars/${id}/${avatarHash}`, options);
+	}
+
+	/**
+	 * Generates a banner URL, e.g. for a user or a guild.
+	 * @param id The id that has the banner splash
+	 * @param bannerHash The hash provided by Discord for this banner
+	 * @param options Optional options for the banner
+	 */
+	public banner(id: string, bannerHash: string, options?: ImageURLOptions): string {
+		return this.makeURL(`/banners/${id}/${bannerHash}`, options);
+	}
+
+	/**
+	 * Generates an icon URL for a channel, e.g. a group DM.
+	 * @param channelId The channel id that has the icon
+	 * @param iconHash The hash provided by Discord for this channel
+	 * @param options Optional options for the icon
+	 */
+	public channelIcon(channelId: string, iconHash: string, options?: ImageURLOptions): string {
+		return this.makeURL(`/channel-icons/${channelId}/${iconHash}`, options);
+	}
+
+	/**
 	 * Generates the default avatar URL for a discriminator.
 	 * @param discriminator The discriminator modulo 5
 	 */
@@ -60,33 +94,13 @@ export class CDN {
 	}
 
 	/**
-	 * Generates a group DM icon URL for a group DM.
-	 * @param channelId The group channel id that has the icon
-	 * @param iconHash The hash provided by Discord for this group DM channel
-	 * @param options Optional options for the icon
-	 */
-	public groupDMIcon(channelId: string, iconHash: string, options?: ImageURLOptions): string {
-		return this.makeURL(`/channel-icons/${channelId}/${iconHash}`, options);
-	}
-
-	/**
-	 * Generates a banner URL for a guild's banner.
-	 * @param guildId The guild id that has the banner splash
-	 * @param bannerHash The hash provided by Discord for this banner
-	 * @param options Optional options for the banner
-	 */
-	public guildBanner(guildId: string, bannerHash: string, options?: ImageURLOptions): string {
-		return this.makeURL(`/banners/${guildId}/${bannerHash}`, options);
-	}
-
-	/**
-	 * Generates an icon URL for a guild's icon.
-	 * @param guildId The guild id that has the icon splash
+	 * Generates an icon URL, e.g. for a guild.
+	 * @param id The id that has the icon splash
 	 * @param iconHash The hash provided by Discord for this icon
 	 * @param options Optional options for the icon
 	 */
-	public guildIcon(guildId: string, iconHash: string, options?: ImageURLOptions): string {
-		return this.makeURL(`/icons/${guildId}/${iconHash}`, options);
+	public icon(id: string, iconHash: string, options?: ImageURLOptions): string {
+		return this.makeURL(`/icons/${id}/${iconHash}`, options);
 	}
 
 	/**
@@ -107,20 +121,6 @@ export class CDN {
 	 */
 	public teamIcon(teamId: string, iconHash: string, options?: ImageURLOptions): string {
 		return this.makeURL(`/team-icons/${teamId}/${iconHash}`, options);
-	}
-
-	/**
-	 * Generates a user avatar URL for a user's avatar.
-	 * @param userId The user id that has the icon
-	 * @param avatarHash The hash provided by Discord for this avatar
-	 * @param options Optional options for the avatar
-	 */
-	public userAvatar(userId: string, avatarHash: string, { dynamic = false, ...options }: ImageURLOptions = {}): string {
-		if (dynamic && avatarHash.startsWith('a_')) {
-			options.extension = 'gif';
-		}
-
-		return this.makeURL(`/avatars/${userId}/${avatarHash}`, options);
 	}
 
 	/**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR generalizes several method names on the CDN class for better forward-compatibility. For instance, user and guild banners use the same route, as well as user and webhook avatars. The descriptions and parameter names were updated as well.

These methods got a rename:
- `groupDMIcon` > `channelIcon`
- `guildBanner` > `banner`
- `guildIcon` > `icon`
- `userAvatar` > `avatar`

**Status and versioning classification:**

- I know how to update typings and have done so, I guess
- This PR includes breaking changes (methods renamed)