### PR TITLE
refactor(RatelimitData): rename to RateLimitData

### DIFF
--- a/packages/rest/src/lib/REST.ts
+++ b/packages/rest/src/lib/REST.ts
@@ -46,9 +46,9 @@ export interface RESTOptions {
 }
 
 /**
- * Data emitted on `RESTEvents.Debug`
+ * Data emitted on `RESTEvents.RateLimited`
  */
-export interface RatelimitData {
+export interface RateLimitData {
 	/**
 	 * The time, in milliseconds, until the request-lock is reset
 	 */
@@ -80,7 +80,7 @@ export interface RatelimitData {
 
 interface RestEvents {
 	restDebug: [info: string];
-	rateLimited: [rateLimitInfo: RatelimitData];
+	rateLimited: [rateLimitInfo: RateLimitData];
 }
 
 export interface REST {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This seems to be the only place where "ratelimit" is used as one word

**Status and versioning classification:**

- I know how to update typings and have done so
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)