### PR TITLE
feat(REST): change api version to v9

### DIFF
--- a/packages/rest/__tests__/DiscordAPIError.test.ts
+++ b/packages/rest/__tests__/DiscordAPIError.test.ts
@@ -6,7 +6,7 @@ test('Unauthorized', () => {
 		0,
 		401,
 		'PATCH',
-		'https://discord.com/api/v8/guilds/:id',
+		'https://discord.com/api/v9/guilds/:id',
 	);
 
 	expect(error.code).toBe(0);
@@ -14,7 +14,7 @@ test('Unauthorized', () => {
 	expect(error.method).toBe('PATCH');
 	expect(error.name).toBe('DiscordAPIError[0]');
 	expect(error.status).toBe(401);
-	expect(error.url).toBe('https://discord.com/api/v8/guilds/:id');
+	expect(error.url).toBe('https://discord.com/api/v9/guilds/:id');
 });
 
 test('Invalid Form Body Error (error.{property}._errors.{index})', () => {
@@ -29,7 +29,7 @@ test('Invalid Form Body Error (error.{property}._errors.{index})', () => {
 		50035,
 		400,
 		'PATCH',
-		'https://discord.com/api/v8/users/@me',
+		'https://discord.com/api/v9/users/@me',
 	);
 
 	expect(error.code).toBe(50035);
@@ -39,7 +39,7 @@ test('Invalid Form Body Error (error.{property}._errors.{index})', () => {
 	expect(error.method).toBe('PATCH');
 	expect(error.name).toBe('DiscordAPIError[50035]');
 	expect(error.status).toBe(400);
-	expect(error.url).toBe('https://discord.com/api/v8/users/@me');
+	expect(error.url).toBe('https://discord.com/api/v9/users/@me');
 });
 
 test('Invalid FormFields Error (error.errors.{property}.{property}.{index}.{property}._errors.{index})', () => {
@@ -56,7 +56,7 @@ test('Invalid FormFields Error (error.errors.{property}.{property}.{index}.{prop
 		50035,
 		400,
 		'POST',
-		'https://discord.com/api/v8/channels/:id',
+		'https://discord.com/api/v9/channels/:id',
 	);
 
 	expect(error.code).toBe(50035);
@@ -66,7 +66,7 @@ test('Invalid FormFields Error (error.errors.{property}.{property}.{index}.{prop
 	expect(error.method).toBe('POST');
 	expect(error.name).toBe('DiscordAPIError[50035]');
 	expect(error.status).toBe(400);
-	expect(error.url).toBe('https://discord.com/api/v8/channels/:id');
+	expect(error.url).toBe('https://discord.com/api/v9/channels/:id');
 });
 
 test('Invalid FormFields Error (error.errors.{property}.{property}._errors.{index}._errors)', () => {
@@ -83,7 +83,7 @@ test('Invalid FormFields Error (error.errors.{property}.{property}._errors.{inde
 		50035,
 		400,
 		'PATCH',
-		'https://discord.com/api/v8/guilds/:id',
+		'https://discord.com/api/v9/guilds/:id',
 	);
 
 	expect(error.code).toBe(50035);
@@ -93,5 +93,5 @@ test('Invalid FormFields Error (error.errors.{property}.{property}._errors.{inde
 	expect(error.method).toBe('PATCH');
 	expect(error.name).toBe('DiscordAPIError[50035]');
 	expect(error.status).toBe(400);
-	expect(error.url).toBe('https://discord.com/api/v8/guilds/:id');
+	expect(error.url).toBe('https://discord.com/api/v9/guilds/:id');
 });

--- a/packages/rest/__tests__/REST.test.ts
+++ b/packages/rest/__tests__/REST.test.ts
@@ -1,7 +1,7 @@
 import nock from 'nock';
 import { DiscordSnowflake } from '@sapphire/snowflake';
 import { REST, DefaultRestOptions } from '../src';
-import { Routes, Snowflake } from 'discord-api-types/v8';
+import { Routes, Snowflake } from 'discord-api-types/v9';
 
 const newSnowflake: Snowflake = DiscordSnowflake.generate().toString();
 

--- a/packages/rest/src/lib/REST.ts
+++ b/packages/rest/src/lib/REST.ts
@@ -40,7 +40,7 @@ export interface RESTOptions {
 	userAgentAppendix: string;
 	/**
 	 * The version of the API to use
-	 * @default '8'
+	 * @default '9'
 	 */
 	version: string;
 }

--- a/packages/rest/src/lib/utils/constants.ts
+++ b/packages/rest/src/lib/utils/constants.ts
@@ -1,4 +1,4 @@
-import { APIVersion } from 'discord-api-types/v8';
+import { APIVersion } from 'discord-api-types/v9';
 import type { RESTOptions } from '../REST';
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
 const Package = require('../../../package.json');


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This updates the API version to v9. The [change log](https://discord.com/developers/docs/change-log#api-v9) doesn't mention any relevant changes, so I think this should be it

**Status and versioning classification:**

- Typings don't need updating