### PR TITLE
feat(CDN): add role icon endpoint

### DIFF
--- a/packages/rest/__tests__/CDN.test.ts
+++ b/packages/rest/__tests__/CDN.test.ts
@@ -64,6 +64,10 @@ test('guildIcon dynamic-not-animated', () => {
 	expect(cdn.icon(id, hash, { dynamic: true })).toBe(`${base}/icons/${id}/${hash}.png`);
 });
 
+test('role icon default', () => {
+	expect(cdn.roleIcon(id, hash)).toBe(`${base}/role-icons/${id}/${hash}.png`);
+});
+
 test('splash default', () => {
 	expect(cdn.splash(id, hash)).toBe(`${base}/splashes/${id}/${hash}.png`);
 });

--- a/packages/rest/src/lib/CDN.ts
+++ b/packages/rest/src/lib/CDN.ts
@@ -109,9 +109,9 @@ export class CDN {
 
 	/**
 	 * Generates a URL for the icon of a role
-	 * @param roleId The id of the role whose icon's URL is to be generated
+	 * @param roleId The id of the role that has the icon
 	 * @param roleIconHash The hash provided by Discord for this role icon
-	 * @param options Optional data for the role icon
+	 * @param options Optional options for the role icon
 	 */
 	public roleIcon(roleId: string, roleIconHash: string, options?: ImageURLOptions): string {
 		return this.makeURL(`/role-icons/${roleId}/${roleIconHash}`, options);

--- a/packages/rest/src/lib/CDN.ts
+++ b/packages/rest/src/lib/CDN.ts
@@ -108,6 +108,16 @@ export class CDN {
 	}
 
 	/**
+	 * Generates a URL for the icon of a role
+	 * @param roleId The id of the role whose icon's URL is to be generated
+	 * @param roleIconHash The hash provided by Discord for this role icon
+	 * @param options Optional data for the role icon
+	 */
+	public roleIcon(roleId: string, roleIconHash: string, options?: ImageURLOptions): string {
+		return this.makeURL(`/role-icons/${roleId}/${roleIconHash}`, options);
+	}
+
+	/**
 	 * Generates a guild invite splash URL for a guild's invite splash.
 	 * @param guildId The guild id that has the invite splash
 	 * @param splashHash The hash provided by Discord for this splash


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds `roleIcon` method to generate URL for a role's icon
- discord/discord-api-docs#3847

**Status and versioning classification:**
- I know how to update typings and have done so
- This PR changes the library's interface (methods or parameters added)
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
