### PR TITLE
fix: use hash instead of animatedHash for default avatar test

### DIFF
--- a/packages/rest/__tests__/CDN.test.ts
+++ b/packages/rest/__tests__/CDN.test.ts
@@ -17,7 +17,7 @@ test('appIcon default', () => {
 });
 
 test('avatar default', () => {
-	expect(cdn.avatar(id, animatedHash)).toBe(`${base}/avatars/${id}/${animatedHash}.png`);
+	expect(cdn.avatar(id, hash)).toBe(`${base}/avatars/${id}/${hash}.png`);
 });
 
 test('avatar dynamic-animated', () => {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

All the other icon tests take `hash` for the default case

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
