### PR TITLE
feat(Requests): add attachment keys and form data for stickers

### DIFF
--- a/packages/rest/__tests__/REST.test.ts
+++ b/packages/rest/__tests__/REST.test.ts
@@ -36,7 +36,7 @@ nock(`${DefaultRestOptions.api}/v${DefaultRestOptions.version}`)
 	.post('/postEcho')
 	.reply(200, (_, body) => body)
 	.post('/postAttachment')
-	.times(3)
+	.times(4)
 	.reply(200, (_, body) => ({
 		body: body
 			.replace(/\r\n/g, '\n')
@@ -139,6 +139,26 @@ test('postAttachment attachment and JSON', async () => {
 			'Content-Disposition: form-data; name="payload_json"',
 			'',
 			'{"foo":"bar"}',
+		].join('\n'),
+	});
+});
+
+test('postAttachment sticker and JSON', async () => {
+	expect(
+		await api.post('/postAttachment', {
+			attachments: [{ key: 'file', fileName: 'sticker.png', rawBuffer: Buffer.from('Sticker') }],
+			body: { foo: 'bar' },
+			dontUsePayloadJSON: true,
+		}),
+	).toStrictEqual({
+		body: [
+			'Content-Disposition: form-data; name="file"; filename="sticker.png"',
+			'Content-Type: image/png',
+			'',
+			'Sticker',
+			'Content-Disposition: form-data; name="foo"',
+			'',
+			'bar',
 		].join('\n'),
 	});
 });

--- a/packages/rest/__tests__/REST.test.ts
+++ b/packages/rest/__tests__/REST.test.ts
@@ -148,7 +148,7 @@ test('postAttachment sticker and JSON', async () => {
 		await api.post('/postAttachment', {
 			attachments: [{ key: 'file', fileName: 'sticker.png', rawBuffer: Buffer.from('Sticker') }],
 			body: { foo: 'bar' },
-			dontUsePayloadJSON: true,
+			appendToFormData: true,
 		}),
 	).toStrictEqual({
 		body: [

--- a/packages/rest/src/lib/RequestManager.ts
+++ b/packages/rest/src/lib/RequestManager.ts
@@ -16,6 +16,7 @@ const agent = new Agent({ keepAlive: true });
  */
 export interface RawAttachment {
 	fileName: string;
+	key?: string;
 	rawBuffer: Buffer;
 }
 
@@ -41,6 +42,10 @@ export interface RequestData {
 	 * The body to send to this request
 	 */
 	body?: unknown;
+	/**
+	 * Whether to append JSON data to form data isntead of `payload_json` when sending attachments
+	 */
+	dontUsePayloadJSON?: boolean;
 	/**
 	 * Additional headers to add to this request
 	 */
@@ -239,13 +244,17 @@ export class RequestManager extends EventEmitter {
 
 			// Attach all files to the request
 			for (const attachment of request.attachments) {
-				formData.append(attachment.fileName, attachment.rawBuffer, attachment.fileName);
+				formData.append(attachment.key ?? attachment.fileName, attachment.rawBuffer, attachment.fileName);
 			}
 
-			// If a JSON body was added as well, attach it to the form data
+			// If a JSON body was added as well, attach it to the form data, using payload_json unless otherwise specified
 			// eslint-disable-next-line no-eq-null
 			if (request.body != null) {
-				formData.append('payload_json', JSON.stringify(request.body));
+				if (request.dontUsePayloadJSON) {
+					for (const [key, value] of Object.entries(request.body as any)) formData.append(key, value);
+				} else {
+					formData.append('payload_json', JSON.stringify(request.body));
+				}
 			}
 
 			// Set the final body to the form data

--- a/packages/rest/src/lib/RequestManager.ts
+++ b/packages/rest/src/lib/RequestManager.ts
@@ -25,6 +25,10 @@ export interface RawAttachment {
  */
 export interface RequestData {
 	/**
+	 * Whether to append JSON data to form data isntead of `payload_json` when sending attachments
+	 */
+	appendToFormData?: boolean;
+	/**
 	 * Files to be attached to this request
 	 */
 	attachments?: RawAttachment[] | undefined;
@@ -42,10 +46,6 @@ export interface RequestData {
 	 * The body to send to this request
 	 */
 	body?: unknown;
-	/**
-	 * Whether to append JSON data to form data isntead of `payload_json` when sending attachments
-	 */
-	dontUsePayloadJSON?: boolean;
 	/**
 	 * Additional headers to add to this request
 	 */
@@ -250,7 +250,7 @@ export class RequestManager extends EventEmitter {
 			// If a JSON body was added as well, attach it to the form data, using payload_json unless otherwise specified
 			// eslint-disable-next-line no-eq-null
 			if (request.body != null) {
-				if (request.dontUsePayloadJSON) {
+				if (request.appendToFormData) {
 					for (const [key, value] of Object.entries(request.body as any)) formData.append(key, value);
 				} else {
 					formData.append('payload_json', JSON.stringify(request.body));

--- a/packages/rest/src/lib/RequestManager.ts
+++ b/packages/rest/src/lib/RequestManager.ts
@@ -15,8 +15,17 @@ const agent = new Agent({ keepAlive: true });
  * Represents an attachment to be added to the request
  */
 export interface RawAttachment {
+	/**
+	 * The name of the file
+	 */
 	fileName: string;
+	/**
+	 * A key to use for the name of the formdata field for this attachment, otherwise the name is used.
+	 */
 	key?: string;
+	/**
+	 * The actual data for the attachment
+	 */
 	rawBuffer: Buffer;
 }
 
@@ -25,7 +34,7 @@ export interface RawAttachment {
  */
 export interface RequestData {
 	/**
-	 * Whether to append JSON data to form data isntead of `payload_json` when sending attachments
+	 * Whether to append JSON data to form data instead of `payload_json` when sending attachments
 	 */
 	appendToFormData?: boolean;
 	/**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds support for stickers endpoints that require special formatting

Ported from https://github.com/discordjs/discord.js/pull/5867

Not tested against the API due to sticker upload being locked behind boosting. Added tests do pass though.

**Status and versioning classification:**

- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
