### PR TITLE
fix(Rest): remove DOM reference types

### DIFF
--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -1,6 +1,3 @@
-// eslint-disable-next-line spaced-comment
-/// <reference lib="dom" />
-
 export * from './lib/CDN';
 export * from './lib/errors/DiscordAPIError';
 export * from './lib/errors/HTTPError';

--- a/packages/rest/src/lib/RequestManager.ts
+++ b/packages/rest/src/lib/RequestManager.ts
@@ -8,6 +8,7 @@ import type { IHandler } from './handlers/IHandler';
 import { SequentialHandler } from './handlers/SequentialHandler';
 import type { RESTOptions, RestEvents } from './REST';
 import { DefaultRestOptions, DefaultUserAgent } from './utils/constants';
+import './global';
 
 let agent: Agent | null = null;
 

--- a/packages/rest/src/lib/global.ts
+++ b/packages/rest/src/lib/global.ts
@@ -1,0 +1,9 @@
+import type * as url from 'node:url';
+
+declare global {
+	let URL: typeof url.URL;
+	type URL = url.URL;
+
+	let URLSearchParams: typeof url.URLSearchParams;
+	type URLSearchParams = url.URLSearchParams;
+}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This reverts #55 and instead augments the global namespace with the missing `URL` and `URLSearchParams` (see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/34960). This means that projects that use @discordjs/rest won't need to have the global namespace polluted with DOM typings (and also things like `document.querySelector('.oh-no')` will compile even in a Node.js environment!), even if `"dom"` isn't included in the user's own TSConfig.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
