### PR TITLE
refactor: rename attachment to file

### DIFF
--- a/packages/rest/__tests__/DiscordAPIError.test.ts
+++ b/packages/rest/__tests__/DiscordAPIError.test.ts
@@ -8,7 +8,7 @@ test('Unauthorized', () => {
 		'PATCH',
 		'https://discord.com/api/v9/guilds/:id',
 		{
-			attachments: undefined,
+			files: undefined,
 			body: undefined,
 		},
 	);
@@ -19,7 +19,7 @@ test('Unauthorized', () => {
 	expect(error.name).toBe('DiscordAPIError[0]');
 	expect(error.status).toBe(401);
 	expect(error.url).toBe('https://discord.com/api/v9/guilds/:id');
-	expect(error.requestBody.attachments).toBe(undefined);
+	expect(error.requestBody.files).toBe(undefined);
 	expect(error.requestBody.json).toBe(undefined);
 });
 
@@ -37,7 +37,7 @@ test('Invalid Form Body Error (error.{property}._errors.{index})', () => {
 		'PATCH',
 		'https://discord.com/api/v9/users/@me',
 		{
-			attachments: undefined,
+			files: undefined,
 			body: {
 				username: 'a',
 			},
@@ -52,7 +52,7 @@ test('Invalid Form Body Error (error.{property}._errors.{index})', () => {
 	expect(error.name).toBe('DiscordAPIError[50035]');
 	expect(error.status).toBe(400);
 	expect(error.url).toBe('https://discord.com/api/v9/users/@me');
-	expect(error.requestBody.attachments).toBe(undefined);
+	expect(error.requestBody.files).toBe(undefined);
 	expect(error.requestBody.json).toStrictEqual({ username: 'a' });
 });
 

--- a/packages/rest/__tests__/REST.test.ts
+++ b/packages/rest/__tests__/REST.test.ts
@@ -38,7 +38,7 @@ nock(`${DefaultRestOptions.api}/v${DefaultRestOptions.version}`)
 	.reply(200, (_, body) => body)
 	.post('/postEcho')
 	.reply(200, (_, body) => body)
-	.post('/postAttachment')
+	.post('/postFile')
 	.times(5)
 	.reply(200, (_, body) => ({
 		body: body
@@ -109,16 +109,16 @@ test('getReason encoded', async () => {
 	expect(await api.get('/getReason', { reason: '😄' })).toStrictEqual({ reason: '%F0%9F%98%84' });
 });
 
-test('postAttachment empty', async () => {
-	expect(await api.post('/postAttachment', { attachments: [] })).toStrictEqual({
+test('postFile empty', async () => {
+	expect(await api.post('/postFile', { files: [] })).toStrictEqual({
 		body: '',
 	});
 });
 
-test('postAttachment attachment', async () => {
+test('postFile file', async () => {
 	expect(
-		await api.post('/postAttachment', {
-			attachments: [{ fileName: 'out.txt', rawBuffer: Buffer.from('Hello') }],
+		await api.post('/postFile', {
+			files: [{ fileName: 'out.txt', rawBuffer: Buffer.from('Hello') }],
 		}),
 	).toStrictEqual({
 		body: [
@@ -130,10 +130,10 @@ test('postAttachment attachment', async () => {
 	});
 });
 
-test('postAttachment attachment and JSON', async () => {
+test('postFile file and JSON', async () => {
 	expect(
-		await api.post('/postAttachment', {
-			attachments: [{ fileName: 'out.txt', rawBuffer: Buffer.from('Hello') }],
+		await api.post('/postFile', {
+			files: [{ fileName: 'out.txt', rawBuffer: Buffer.from('Hello') }],
 			body: { foo: 'bar' },
 		}),
 	).toStrictEqual({
@@ -149,14 +149,14 @@ test('postAttachment attachment and JSON', async () => {
 	});
 });
 
-test('postAttachment attachments and JSON', async () => {
+test('postFile files and JSON', async () => {
 	expect(
-		await api.post('/postAttachment', {
-			attachments: [
+		await api.post('/postFile', {
+			files: [
 				{ fileName: 'out.txt', rawBuffer: Buffer.from('Hello') },
 				{ fileName: 'out.txt', rawBuffer: Buffer.from('Hi') },
 			],
-			body: { attachments: [{ id: 0, description: 'test' }] },
+			body: { files: [{ id: 0, description: 'test' }] },
 		}),
 	).toStrictEqual({
 		body: [
@@ -170,15 +170,15 @@ test('postAttachment attachments and JSON', async () => {
 			'Hi',
 			'Content-Disposition: form-data; name="payload_json"',
 			'',
-			'{"attachments":[{"id":0,"description":"test"}]}',
+			'{"files":[{"id":0,"description":"test"}]}',
 		].join('\n'),
 	});
 });
 
-test('postAttachment sticker and JSON', async () => {
+test('postFile sticker and JSON', async () => {
 	expect(
-		await api.post('/postAttachment', {
-			attachments: [{ key: 'file', fileName: 'sticker.png', rawBuffer: Buffer.from('Sticker') }],
+		await api.post('/postFile', {
+			files: [{ key: 'file', fileName: 'sticker.png', rawBuffer: Buffer.from('Sticker') }],
 			body: { foo: 'bar' },
 			appendToFormData: true,
 		}),
@@ -242,7 +242,7 @@ test('Request and Response Events', async () => {
 			method: 'get',
 			path: '/request',
 			route: '/request',
-			data: { attachments: undefined, body: undefined },
+			data: { files: undefined, body: undefined },
 			retries: 0,
 		}) as APIRequest,
 	);
@@ -251,7 +251,7 @@ test('Request and Response Events', async () => {
 			method: 'get',
 			path: '/request',
 			route: '/request',
-			data: { attachments: undefined, body: undefined },
+			data: { files: undefined, body: undefined },
 			retries: 0,
 		}) as APIRequest,
 		expect.objectContaining({ status: 200, statusText: 'OK' }) as Response,

--- a/packages/rest/src/lib/REST.ts
+++ b/packages/rest/src/lib/REST.ts
@@ -142,7 +142,7 @@ export interface APIRequest {
 	/**
 	 * The data that was used to form the body of this request
 	 */
-	data: Pick<InternalRequest, 'attachments' | 'body'>;
+	data: Pick<InternalRequest, 'files' | 'body'>;
 	/**
 	 * The number of times this request has been attempted
 	 */

--- a/packages/rest/src/lib/errors/DiscordAPIError.ts
+++ b/packages/rest/src/lib/errors/DiscordAPIError.ts
@@ -1,4 +1,4 @@
-import type { InternalRequest, RawAttachment } from '../RequestManager';
+import type { InternalRequest, RawFile } from '../RequestManager';
 
 interface DiscordErrorFieldInformation {
 	code: string;
@@ -23,7 +23,7 @@ export interface OAuthErrorData {
 }
 
 export interface RequestBody {
-	attachments: RawAttachment[] | undefined;
+	files: RawFile[] | undefined;
 	json: unknown | undefined;
 }
 
@@ -56,11 +56,11 @@ export class DiscordAPIError extends Error {
 		public status: number,
 		public method: string,
 		public url: string,
-		bodyData: Pick<InternalRequest, 'attachments' | 'body'>,
+		bodyData: Pick<InternalRequest, 'files' | 'body'>,
 	) {
 		super(DiscordAPIError.getMessage(rawError));
 
-		this.requestBody = { attachments: bodyData.attachments, json: bodyData.body };
+		this.requestBody = { files: bodyData.files, json: bodyData.body };
 	}
 
 	/**

--- a/packages/rest/src/lib/errors/HTTPError.ts
+++ b/packages/rest/src/lib/errors/HTTPError.ts
@@ -21,10 +21,10 @@ export class HTTPError extends Error {
 		public status: number,
 		public method: string,
 		public url: string,
-		bodyData: Pick<InternalRequest, 'attachments' | 'body'>,
+		bodyData: Pick<InternalRequest, 'files' | 'body'>,
 	) {
 		super(message);
 
-		this.requestBody = { attachments: bodyData.attachments, json: bodyData.body };
+		this.requestBody = { files: bodyData.files, json: bodyData.body };
 	}
 }

--- a/packages/rest/src/lib/handlers/IHandler.ts
+++ b/packages/rest/src/lib/handlers/IHandler.ts
@@ -6,6 +6,6 @@ export interface IHandler {
 		routeId: RouteData,
 		url: string,
 		options: RequestInit,
-		bodyData: Pick<InternalRequest, 'attachments' | 'body'>,
+		bodyData: Pick<InternalRequest, 'files' | 'body'>,
 	): Promise<unknown>;
 }

--- a/packages/rest/src/lib/handlers/SequentialHandler.ts
+++ b/packages/rest/src/lib/handlers/SequentialHandler.ts
@@ -168,7 +168,7 @@ export class SequentialHandler {
 		routeId: RouteData,
 		url: string,
 		options: RequestInit,
-		bodyData: Pick<InternalRequest, 'attachments' | 'body'>,
+		bodyData: Pick<InternalRequest, 'files' | 'body'>,
 	): Promise<unknown> {
 		let queue = this.#asyncQueue;
 		let queueType = QueueType.Standard;
@@ -225,7 +225,7 @@ export class SequentialHandler {
 		routeId: RouteData,
 		url: string,
 		options: RequestInit,
-		bodyData: Pick<InternalRequest, 'attachments' | 'body'>,
+		bodyData: Pick<InternalRequest, 'files' | 'body'>,
 		retries = 0,
 	): Promise<unknown> {
 		/*


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Discord and djs both use files to classify all attachments, we should follow suit.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
